### PR TITLE
Picking up Mocha from the node_components

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node ./src/server.js",
     "dev": "nodemon ./src/server.js",
-    "test": "./node_modules/mocha/bin/mocha -R spec src/**/*.spec.js"
+    "test": "node_modules/.bin/mocha"
   },
   "keywords": [
     "node.js",
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "mocha": "^5.2.0",
+    "mocha-multi-reporters": "^1.1.7",
     "nock": "^10.0.4",
     "nodemon": "^1.18.9"
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node ./src/server.js",
     "dev": "nodemon ./src/server.js",
-    "test": "mocha -R spec src/**/*.spec.js"
+    "test": "./node_modules/mocha/bin/mocha -R spec src/**/*.spec.js"
   },
   "keywords": [
     "node.js",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,5 @@
+--reporter mocha-multi-reporters 
+--reporter-options configFile=test/multireport.opts
+--ui bdd
+--recursive
+src/**/*.spec.js

--- a/test/multireport.opts
+++ b/test/multireport.opts
@@ -1,0 +1,6 @@
+{
+    "reporterEnabled": "spec, xunit",
+    "xunitReporterOptions": {
+        "output": "test-reports/reports.xml"
+    }
+}


### PR DESCRIPTION
The npm script currently expects that mocha is installed locally, which isn't always the case for jenkins workers.